### PR TITLE
Feature/retrieve-h5p-save-data

### DIFF
--- a/admin/class-h5p-content-admin.php
+++ b/admin/class-h5p-content-admin.php
@@ -629,7 +629,7 @@ class H5PContentAdmin {
    * @param int $current
    * @return int
    */
-  private function get_disabled_content_features($core, &$content) {
+  public function get_disabled_content_features($core, &$content) {
     $set = array(
       H5PCore::DISPLAY_OPTION_FRAME => filter_input(INPUT_POST, 'frame', FILTER_VALIDATE_BOOLEAN),
       H5PCore::DISPLAY_OPTION_DOWNLOAD => filter_input(INPUT_POST, 'download', FILTER_VALIDATE_BOOLEAN),

--- a/admin/class-h5p-plugin-admin.php
+++ b/admin/class-h5p-plugin-admin.php
@@ -169,7 +169,6 @@ class H5P_Plugin_Admin {
     $core = $plugin->get_h5p_instance('core');
     $action = $_GET['action'];
     $content_id = $_GET['content_id'];
-    
 
     if(!isset($action)) {
       $core->h5pF->setErrorMessage(__('No action set', $this->plugin_slug));
@@ -192,17 +191,20 @@ class H5P_Plugin_Admin {
     try{
       $save_data = $wpdb->get_var($wpdb->prepare(
         "SELECT `data`
-        FROM {$wpdb->prefix}h5p_contents_user_data
-        WHERE user_id = %d
-        AND content_id = %d",
+        FROM `{$wpdb->prefix}h5p_contents_user_data`
+        WHERE `user_id` = %d
+        AND `content_id` = %d",
         $user_id,
         $content_id
       ));
 
-      wp_send_json($save_data);
+      $decoded = json_decode($save_data);
+      header('Content-Type: application/json; charset=utf-8');
+      wp_send_json($decoded);
     }
     catch(Exception $ex) {
       error_log("Error Message: " . $ex->getMessage());
+      http_response_code(500);
       return;
     }
 

--- a/admin/class-h5p-plugin-admin.php
+++ b/admin/class-h5p-plugin-admin.php
@@ -120,6 +120,9 @@ class H5P_Plugin_Admin {
     // AJAX for creating an h5p content
     add_action('wp_ajax_create_h5p_content', array($this, 'ajax_create_content'));
 
+    // AJAX for pulling h5p save data for specific user and content
+    add_action('wp_ajax_get_content_save_data', array($this, 'ajax_get_user_h5p_save_data'));
+
     // Display admin notices
     add_action('admin_notices', array($this, 'admin_notices'));
 
@@ -157,6 +160,54 @@ class H5P_Plugin_Admin {
   function add_settings_link($links) {
     $links[] = '<a href="' . admin_url('options-general.php?page=h5p_settings') . '">Settings</a>';
     return $links;
+  }
+
+
+  public function ajax_get_user_h5p_save_data() {
+    global $wpdb;
+    $plugin = H5P_Plugin::get_instance();
+    $core = $plugin->get_h5p_instance('core');
+    $action = $_GET['action'];
+    $content_id = $_GET['content_id'];
+    
+
+    if(!isset($action)) {
+      $core->h5pF->setErrorMessage(__('No action set', $this->plugin_slug));
+      return;
+    }
+    
+    if(strcmp($action, 'get_content_save_data') !== 0) {
+      $core->h5pF->setErrorMessage(__('Invalid action set', $this->plugin_slug));
+      return;
+    }
+
+    $user_id = get_current_user_id();
+
+    if(!isset($user_id) || !is_numeric($user_id))
+    {
+        error_log("Could not retrieve current user");
+        return;
+    }
+
+    try{
+      $save_data = $wpdb->get_var($wpdb->prepare(
+        "SELECT `data`
+        FROM {$wpdb->prefix}h5p_contents_user_data
+        WHERE user_id = %d
+        AND content_id = %d",
+        $user_id,
+        $content_id
+      ));
+
+      wp_send_json($save_data);
+    }
+    catch(Exception $ex) {
+      error_log("Error Message: " . $ex->getMessage());
+      return;
+    }
+
+    return;
+
   }
 
   /**
@@ -215,6 +266,7 @@ class H5P_Plugin_Admin {
       // Save new content
       $content['id'] = $core->saveContent($content);
       $editor = $this->content->get_h5peditor_instance();
+      $this->content->get_disabled_content_features($core, $content);
       // Process a nested h5p content
       $editor->processParameters($content['id'], $content['library'], $decoded->h5pContentParameters->params, NULL, NULL);
     }

--- a/admin/views/new-content.php
+++ b/admin/views/new-content.php
@@ -65,7 +65,7 @@
           <h2><?php esc_html_e('Display Options', $this->plugin_slug); ?></h2>
           <div class="h5p-action-bar-settings h5p-panel">
             <label>
-              <input name="frame" type="checkbox" class="h5p-visibility-toggler" data-h5p-visibility-subject-selector=".h5p-action-bar-buttons-settings" value="true"<?php if ($display_options[H5PCore::DISPLAY_OPTION_FRAME]): ?><?php endif; ?>/>
+              <input name="frame" type="checkbox" class="h5p-visibility-toggler" data-h5p-visibility-subject-selector=".h5p-action-bar-buttons-settings" value="true"<?php if ($display_options[H5PCore::DISPLAY_OPTION_FRAME]): ?> checked="checked"<?php endif; ?>/>
               <?php _e("Display toolbar below content", $this->plugin_slug); ?>
             </label>
             <?php if (isset($display_options[H5PCore::DISPLAY_OPTION_DOWNLOAD]) || isset($display_options[H5PCore::DISPLAY_OPTION_EMBED]) || isset($display_options[H5PCore::DISPLAY_OPTION_COPYRIGHT])) : ?>

--- a/admin/views/new-content.php
+++ b/admin/views/new-content.php
@@ -65,7 +65,7 @@
           <h2><?php esc_html_e('Display Options', $this->plugin_slug); ?></h2>
           <div class="h5p-action-bar-settings h5p-panel">
             <label>
-              <input name="frame" type="checkbox" class="h5p-visibility-toggler" data-h5p-visibility-subject-selector=".h5p-action-bar-buttons-settings" value="true"<?php if ($display_options[H5PCore::DISPLAY_OPTION_FRAME]): ?> checked="checked"<?php endif; ?>/>
+              <input name="frame" type="checkbox" class="h5p-visibility-toggler" data-h5p-visibility-subject-selector=".h5p-action-bar-buttons-settings" value="true"<?php if ($display_options[H5PCore::DISPLAY_OPTION_FRAME]): ?><?php endif; ?>/>
               <?php _e("Display toolbar below content", $this->plugin_slug); ?>
             </label>
             <?php if (isset($display_options[H5PCore::DISPLAY_OPTION_DOWNLOAD]) || isset($display_options[H5PCore::DISPLAY_OPTION_EMBED]) || isset($display_options[H5PCore::DISPLAY_OPTION_COPYRIGHT])) : ?>


### PR DESCRIPTION
- Adds a wp-admin endpoint to the wp plugin for use in h5p-likert. The feature intends to be able to pull h5p save data from the wp database for any current wp user when supplied with an h5p content id.